### PR TITLE
Remove duplicate $args['button_id']

### DIFF
--- a/src/views/blocks/tickets/submit-button-modal.php
+++ b/src/views/blocks/tickets/submit-button-modal.php
@@ -58,7 +58,6 @@ $args = [
 	'button_disabled'         => true,
 	'button_id'               => 'tribe-tickets__submit',
 	'button_name'             => $provider_id . '_get_tickets',
-	'button_id'               => 'tribe-tickets__submit',
 	'button_text'             => $button_text,
 	'button_type'             => 'submit',
 	'close_event'             => 'tribe_dialog_close_ar_modal',


### PR DESCRIPTION
In the list of `$args`, `button_id` is listed twice. This PR removes the duplicate.